### PR TITLE
Add Unity skeleton with basic scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # ZenGarden
 This Project aims to Program a Pixel art phone game that is focused on self-improvement via leveling up your own little Zen Garden!
+
+## Unity Project Setup
+
+1. Open **Unity/ZenGarden** with Unity 2020.3 or newer.
+2. Load the scene located at `Assets/Scenes/ZenGardenMain.unity`.
+3. Attach `ZenGardenManager` and `DatabaseConnector` scripts to appropriate GameObjects.
+
+Builds can be created using Unity's build settings once the scene is loaded.

--- a/Unity/ZenGarden/Assets/Scenes/ZenGardenMain.unity
+++ b/Unity/ZenGarden/Assets/Scenes/ZenGardenMain.unity
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 33}
+  - component: {fileID: 23}
+  m_Layer: 0
+  m_Name: CentralSquare
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 5, y: 0.2, z: 5}
+--- !u!33 &33
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1}
+  m_Mesh: {fileID: 0}
+--- !u!23 &23
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1}

--- a/Unity/ZenGarden/Assets/Scripts/DatabaseConnector.cs
+++ b/Unity/ZenGarden/Assets/Scripts/DatabaseConnector.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Placeholder for saving and loading Zen Garden data.
+/// Replace with real persistence logic (local file or remote service).
+/// </summary>
+public class DatabaseConnector : MonoBehaviour
+{
+    void Awake()
+    {
+        // TODO: Implement persistence layer
+    }
+}

--- a/Unity/ZenGarden/Assets/Scripts/ZenGardenManager.cs
+++ b/Unity/ZenGarden/Assets/Scripts/ZenGardenManager.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles the basic level logic and object placement for the Zen Garden.
+/// This script currently contains placeholder logic.
+/// </summary>
+public class ZenGardenManager : MonoBehaviour
+{
+    void Start()
+    {
+        // Initialize your Zen Garden here
+    }
+
+    void Update()
+    {
+        // Update objects each frame
+    }
+}


### PR DESCRIPTION
## Summary
- set up Unity/ZenGarden skeleton
- add minimal scene with a central square
- create placeholder scripts for game logic and persistence
- document Unity setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684024efd898832fb0eedd35ed4ede61